### PR TITLE
compile gromacs with SSE2 only

### DIFF
--- a/fedora
+++ b/fedora
@@ -25,7 +25,7 @@ RUN pip install --user codecov coverxygen
 RUN if [ -n "${GMX_BRANCH}" ]; then \
   git clone --depth 1 -b "${GMX_BRANCH}" https://github.com/gromacs/gromacs.git && \
   mkdir gromacs/build && cd gromacs/build && \
-  cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
+  cmake -DCMAKE_INSTALL_PREFIX=/usr -DGMX_SIMD=SSE2 .. && \
   make -j3; \
 fi
 USER root

--- a/ubuntu
+++ b/ubuntu
@@ -31,7 +31,7 @@ RUN pip install --user codecov coverxygen
 RUN if [ -n "${GMX_BRANCH}" ]; then \
   git clone --depth 1 -b "${GMX_BRANCH}" https://github.com/gromacs/gromacs.git && \
   mkdir gromacs/build && cd gromacs/build && \
-  cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
+  cmake -DCMAKE_INSTALL_PREFIX=/usr -DGMX_SIMD=SSE2 .. && \
   make -j3; \
 fi
 USER root


### PR DESCRIPTION
Hopefully, this fixes the **illegal instruction** error, when running `csg_* --help` (as part of the build) on travis.