### PR TITLE
Revert "fedora: add pymol as well"

### DIFF
--- a/fedora
+++ b/fedora
@@ -4,7 +4,7 @@ ARG GMX_BRANCH
 ARG GMX_DOUBLE
 ARG PYTHON
 
-RUN dnf -y install make cmake valgrind git gcc-c++ expat-devel fftw-devel gsl-devel boost-devel txt2tags sqlite-devel ccache procps-ng octave gnuplot-minimal psmisc ghostscript texlive doxygen texlive-appendix texlive-wrapfig texlive-a4wide texlive-xstring vim-minimal clang llvm compiler-rt python-pip python3-lxml python3-numpy inkscape transfig texlive-units texlive-sidecap texlive-bclogo texlive-mdframed texlive-braket graphviz wget hdf5-devel lammps libint2-devel eigen3-devel libxc-devel ceres-solver-devel ImageMagick ghostscript-tools-dvipdf python3-espresso-openmpi sudo curl pymol
+RUN dnf -y install make cmake valgrind git gcc-c++ expat-devel fftw-devel gsl-devel boost-devel txt2tags sqlite-devel ccache procps-ng octave gnuplot-minimal psmisc ghostscript texlive doxygen texlive-appendix texlive-wrapfig texlive-a4wide texlive-xstring vim-minimal clang llvm compiler-rt python-pip python3-lxml python3-numpy inkscape transfig texlive-units texlive-sidecap texlive-bclogo texlive-mdframed texlive-braket graphviz wget hdf5-devel lammps libint2-devel eigen3-devel libxc-devel ceres-solver-devel ImageMagick ghostscript-tools-dvipdf python3-espresso-openmpi sudo curl
 
 # set https://github.com/votca/buildenv/issues/22
 RUN alternatives --set gnuplot /usr/bin/gnuplot-minimal


### PR DESCRIPTION
Reverts votca/buildenv#35

Pymol is dead on Fedora: https://bugzilla.redhat.com/show_bug.cgi?id=1675704