### PR TITLE
Revert "*: codecov fix got moved to votca"

### DIFF
--- a/fedora
+++ b/fedora
@@ -13,7 +13,7 @@ RUN alternatives --set gnuplot /usr/bin/gnuplot-minimal
 # parallel build might trigger a raise condition for non-exisiting latex.fmt when multiple latex get executed
 RUN fmtutil-sys --all
 
-RUN wget -O /usr/bin/codecov https://raw.githubusercontent.com/votca/codecov-bash/master/codecov 
+RUN wget -O /usr/bin/codecov https://raw.githubusercontent.com/junghans/codecov-bash/master/codecov
 RUN chmod +x /usr/bin/codecov
 
 # install fedora's gromacs

--- a/ubuntu
+++ b/ubuntu
@@ -14,7 +14,7 @@ RUN apt-get -qq install -y texlive-latex-extra psmisc texlive-pstricks libeigen3
 # parallel build might trigger a raise condition for non-exisiting latex.fmt when multiple latex get executed
 RUN fmtutil-sys --all
 
-RUN wget -O /usr/bin/codecov https://raw.githubusercontent.com/votca/codecov-bash/master/codecov 
+RUN wget -O /usr/bin/codecov https://raw.githubusercontent.com/junghans/codecov-bash/master/codecov
 RUN chmod +x /usr/bin/codecov
 
 # install ubuntu's gromacs


### PR DESCRIPTION
This reverts commit 286eec7395daa3c27125754d826a96057df8c3ee (part of #31).
Upstream issue (https://github.com/codecov/codecov-bash/pull/164) has been fixed.