### PR TITLE
*: use github action user id

### DIFF
--- a/fedora
+++ b/fedora
@@ -17,7 +17,7 @@ RUN if [ -z "${GMX_BRANCH}" ]; then \
   dnf -y install gromacs-devel gromacs gromacs-openmpi; \
 fi
 
-RUN useradd -m -G wheel votca
+RUN useradd -m -G wheel -u 1001 votca
 RUN echo '%wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER votca
 ENV PATH=/usr/lib64/ccache:/usr/lib64/openmpi/bin${PATH:+:}${PATH}

--- a/opensuse
+++ b/opensuse
@@ -15,7 +15,7 @@ RUN if [ -z "${GMX_BRANCH}" ]; then \
 fi
 
 RUN groupadd -r wheel
-RUN useradd -m -G wheel votca
+RUN useradd -m -G wheel -u 1001 votca
 RUN echo '%wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER votca
 ENV PATH=/usr/lib64/ccache:/usr/lib64/mpi/gcc/openmpi2/bin${PATH:+:}${PATH}

--- a/ubuntu
+++ b/ubuntu
@@ -21,7 +21,7 @@ RUN if [ -z "${GMX_BRANCH}" ]; then \
   apt-get install -y libgromacs-dev gromacs-openmpi; \
 fi
 
-RUN useradd -m -G sudo votca
+RUN useradd -m -G sudo -u 1001 votca
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER votca
 ENV PATH=/usr/lib/ccache${PATH:+:}${PATH}


### PR DESCRIPTION
Github actions uses:
```
uid=1001(runner) gid=116(docker) groups=116(docker),4(adm),101(systemd-journal)
```
as user, but our containers have:
```
uid=1000(votca) gid=1000(votca) groups=1000(votca),10(wheel)
```
which leads to permission problem when mounting the files system from the outside.

As we cannot really change all file permission let's just try to make the uids the same.