### PR TITLE
opensuse: add kokkos-devel

### DIFF
--- a/opensuse
+++ b/opensuse
@@ -9,7 +9,7 @@ RUN zypper dup -y && \
       texlive-xstring vim clang llvm python3-pip python3-lxml python3-numpy python3-Sphinx python3-nbsphinx python3-recommonmark python3-sphinx_rtd_theme transfig texlive-units texlive-sidecap \
       texlive-bclogo texlive-mdframed texlive-type1cm texlive-braket texlive-dvips-bin graphviz wget hdf5-devel lammps eigen3-devel libxc-devel ImageMagick sudo curl ninja clang-devel llvm-devel \
       libboost_filesystem-devel libboost_program_options-devel libboost_serialization-devel libboost_system-devel libboost_test-devel libboost_timer-devel texlive-bibtex-bin texlive-makeindex-bin \
-      zlib-devel texlive-collection-latex texlive-helvetic texlive-courier python3-espressomd python3-cma zstd && \
+      zlib-devel texlive-collection-latex texlive-helvetic texlive-courier python3-espressomd python3-cma zstd kokkos-devel && \
     zypper clean
 
 RUN wget -O /usr/bin/codecov https://raw.githubusercontent.com/junghans/codecov-bash/master/codecov


### PR DESCRIPTION
https://build.opensuse.org/request/show/800834 is done, so we can enable kokkos on opensuse.