### PR TITLE
add tiny container for votca/actions

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -29,6 +29,7 @@ jobs:
           - {tag: 'fedora_gmx9999_d', dockerfile: 'fedora', build_args: 'GMX_BRANCH=master,GMX_DOUBLE=ON'}
           - {tag: 'fedora_gmx9999', dockerfile: 'fedora', build_args: 'GMX_BRANCH=master'}
           - {tag: 'fedora_nogmx', dockerfile: 'fedora', build_args: 'GMX_BRANCH=none'}
+          - {tag: 'actions', dockerfile: 'actions'}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/actions
+++ b/actions
@@ -1,0 +1,6 @@
+FROM fedora:latest
+
+RUN dnf -y install git && dnf clean all
+
+RUN useradd -m -G wheel -u 1001 votca
+USER votca


### PR DESCRIPTION
`votca/actions/setup` only uses bash and git, so this new container will avoid pulling our 3GB standard buildenv container.