### PR TITLE
opensuse,ubuntu: remove sphinx deps

### DIFF
--- a/opensuse
+++ b/opensuse
@@ -6,11 +6,11 @@ ARG GMX_DOUBLE
 RUN zypper dup -y && \
     zypper install -y \
       make cmake valgrind git gcc-c++ libexpat-devel fftw-devel boost-devel txt2tags ccache procps gnuplot psmisc ghostscript texlive doxygen texlive-appendix texlive-wrapfig texlive-a4wide \
-      texlive-xstring vim clang llvm python3-pip python3-lxml python3-numpy python3-Sphinx python3-nbsphinx python3-recommonmark python3-sphinx_rtd_theme python3-ipykernel python3-seaborn \
-      python3-pandas transfig texlive-units texlive-sidecap texlive-bclogo texlive-mdframed texlive-type1cm texlive-braket texlive-dvips-bin graphviz wget hdf5-devel lammps eigen3-devel libxc-devel \
+      texlive-xstring vim clang llvm python3-pip python3-lxml python3-numpy \
+      transfig texlive-units texlive-sidecap texlive-bclogo texlive-mdframed texlive-type1cm texlive-braket texlive-dvips-bin graphviz wget hdf5-devel lammps eigen3-devel libxc-devel \
       ImageMagick sudo curl ninja clang-devel llvm-devel libboost_filesystem-devel libboost_program_options-devel libboost_serialization-devel libboost_system-devel libboost_regex-devel \
       libboost_test-devel libboost_timer-devel texlive-bibtex-bin texlive-makeindex-bin zlib-devel texlive-collection-latex texlive-helvetic texlive-courier python3-cma zstd \
-      kokkos-devel libomp-devel pandoc libint-devel && \
+      kokkos-devel libomp-devel libint-devel && \
     zypper clean
 
 RUN wget -O /usr/bin/codecov https://raw.githubusercontent.com/junghans/codecov-bash/master/codecov

--- a/ubuntu
+++ b/ubuntu
@@ -9,8 +9,8 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
        make cmake valgrind git g++ libexpat-dev libfftw3-dev libboost-all-dev txt2tags ccache gnuplot python3-numpy python3-numpy ghostscript texlive doxygen vim clang llvm python3-pip python3-lxml \
-       transfig wget libhdf5-dev graphviz pkg-config texlive-latex-extra psmisc texlive-pstricks libeigen3-dev libxc-dev sudo curl pymol clang-tidy ninja-build libclang-dev llvm-dev python3-sphinx \
-       python3-nbsphinx python3-recommonmark python3-sphinx-rtd-theme python3-ipykernel clang-format software-properties-common zstd  libint2-dev && \
+       transfig wget libhdf5-dev graphviz pkg-config texlive-latex-extra psmisc texlive-pstricks libeigen3-dev libxc-dev sudo curl pymol clang-tidy ninja-build libclang-dev llvm-dev \
+       clang-format software-properties-common zstd libint2-dev && \
     apt-get purge --autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
We only build sphinx on Fedora or let's remove the unneeded packages.