### PR TITLE
Revert "GHA: used gmx's 3288-fileio instead of master for now"

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -28,8 +28,8 @@ jobs:
           - {dockerfile: 'fedora',   tag: 'gmx2020',   build_args: 'GMX_BRANCH=release-2020'}
           - {dockerfile: 'fedora',   tag: 'gmx2021_d', build_args: 'GMX_BRANCH=release-2021,GMX_DOUBLE=ON'}
           - {dockerfile: 'fedora',   tag: 'gmx2021',   build_args: 'GMX_BRANCH=release-2021'}
-          - {dockerfile: 'fedora',   tag: 'gmx9999_d', build_args: 'GMX_BRANCH=3288-fileio,GMX_DOUBLE=ON'}
-          - {dockerfile: 'fedora',   tag: 'gmx9999',   build_args: 'GMX_BRANCH=3288-fileio'}
+          - {dockerfile: 'fedora',   tag: 'gmx9999_d', build_args: 'GMX_BRANCH=master,GMX_DOUBLE=ON'}
+          - {dockerfile: 'fedora',   tag: 'gmx9999',   build_args: 'GMX_BRANCH=master'}
           - {dockerfile: 'fedora',   tag: 'nogmx',     build_args: 'GMX_BRANCH=none'}
           - {dockerfile: 'fedora',   tag: 'intel',     build_args: 'INTEL=yes'}
           - {dockerfile: 'actions',  tag: 'latest'}


### PR DESCRIPTION
This reverts commit 0f8106db6a7e81a8c9fb92ff620031ec50692646.

Was part of #132