### PR TITLE
Revert "GHA: use docker v2 action"

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -22,13 +22,13 @@ jobs:
           - {dockerfile: 'ubuntu',   tag: 'devel',     build_args: 'TAG=devel', continue-on-error: 'true'}
           - {dockerfile: 'ubuntu',   tag: '18.04',     build_args: 'TAG=18.04'}
           - {dockerfile: 'opensuse', tag: 'latest'}
-          - {dockerfile: 'fedora',   tag: 'gmx2019_d', build_args: 'GMX_BRANCH=release-2019', build_args2: 'GMX_DOUBLE=ON'}
+          - {dockerfile: 'fedora',   tag: 'gmx2019_d', build_args: 'GMX_BRANCH=release-2019,GMX_DOUBLE=ON'}
           - {dockerfile: 'fedora',   tag: 'gmx2019',   build_args: 'GMX_BRANCH=release-2019'}
-          - {dockerfile: 'fedora',   tag: 'gmx2020_d', build_args: 'GMX_BRANCH=release-2020', build_args2: 'GMX_DOUBLE=ON'}
+          - {dockerfile: 'fedora',   tag: 'gmx2020_d', build_args: 'GMX_BRANCH=release-2020,GMX_DOUBLE=ON'}
           - {dockerfile: 'fedora',   tag: 'gmx2020',   build_args: 'GMX_BRANCH=release-2020'}
-          - {dockerfile: 'fedora',   tag: 'gmx2021_d', build_args: 'GMX_BRANCH=release-2021', build_args2: 'GMX_DOUBLE=ON'}
+          - {dockerfile: 'fedora',   tag: 'gmx2021_d', build_args: 'GMX_BRANCH=release-2021,GMX_DOUBLE=ON'}
           - {dockerfile: 'fedora',   tag: 'gmx2021',   build_args: 'GMX_BRANCH=release-2021'}
-          - {dockerfile: 'fedora',   tag: 'gmx9999_d', build_args: 'GMX_BRANCH=master', build_args2: 'GMX_DOUBLE=ON'}
+          - {dockerfile: 'fedora',   tag: 'gmx9999_d', build_args: 'GMX_BRANCH=master,GMX_DOUBLE=ON'}
           - {dockerfile: 'fedora',   tag: 'gmx9999',   build_args: 'GMX_BRANCH=master'}
           - {dockerfile: 'fedora',   tag: 'nogmx',     build_args: 'GMX_BRANCH=none'}
           - {dockerfile: 'fedora',   tag: 'intel',     build_args: 'INTEL=yes'}
@@ -37,30 +37,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout out code
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to GitLab
-        uses: docker/login-action@v1
+        uses: actions/checkout@v2.3.2
+      - name: Build Docker images for GitLab
+        uses: docker/build-push-action@v1.1.0
         with:
+          repository: votca/buildenv/${{ matrix.config.dockerfile }}
           registry: registry.gitlab.com
           username: votca-bot
           password: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
-      - name: Login to Github Container Registry
-        uses: docker/login-action@v1
+          tags: ${{ matrix.config.tag }}
+          dockerfile: ${{ matrix.config.dockerfile }}
+          build_args: ${{ matrix.config.build_args }}
+          push: ${{ github.event_name == 'push' ||  github.event_name == 'schedule' }}
+      - name: Build Docker images for Github Container Registry
+        uses: docker/build-push-action@v1.1.0
         with:
+          repository: votca/buildenv/${{ matrix.config.dockerfile }}
           registry: ghcr.io
           username: votca-bot
           password: ${{ secrets.VOTCA_BOT_TOKEN }}
-      - name: Build and push 
-        uses: docker/build-push-action@v2
-        with:
-          tags: |
-            registry.gitlab.com/votca/buildenv/${{ matrix.config.dockerfile }}:${{ matrix.config.tag }}
-            ghcr.io/votca/buildenv/${{ matrix.config.dockerfile }}:${{ matrix.config.tag }}
-          file: ${{ matrix.config.dockerfile }}
-          build-args: |
-            ${{ matrix.config.build_args }}
-            ${{ matrix.config.build_args2 }}
-          pull: true
+          tags: ${{ matrix.config.tag }}
+          dockerfile: ${{ matrix.config.dockerfile }}
+          build_args: ${{ matrix.config.build_args }}
           push: ${{ github.event_name == 'push' ||  github.event_name == 'schedule' }}

--- a/ubuntu
+++ b/ubuntu
@@ -9,7 +9,7 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
        make cmake valgrind git g++ libexpat-dev libfftw3-dev libboost-all-dev txt2tags ccache gnuplot python3-numpy python3-numpy ghostscript texlive doxygen vim clang llvm python3-pip python3-lxml \
-       transfig wget libhdf5-dev graphviz pkg-config texlive-latex-extra psmisc texlive-pstricks libeigen3-dev libxc-dev sudo curl pymol clang-tidy ninja-build libclang-dev llvm-dev \
+       transfig wget libhdf5-dev graphviz pkg-config texlive-latex-extra psmisc texlive-pstricks libeigen3-dev libxc-dev sudo curl clang-tidy ninja-build libclang-dev llvm-dev \
        clang-format software-properties-common zstd libint2-dev libpugixml-dev && \
     apt-get purge --autoremove -y && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu
+++ b/ubuntu
@@ -9,7 +9,7 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
        make cmake valgrind git g++ libexpat-dev libfftw3-dev libboost-all-dev txt2tags ccache gnuplot python3-numpy python3-numpy ghostscript texlive doxygen vim clang llvm python3-pip python3-lxml \
-       transfig wget libhdf5-dev graphviz pkg-config texlive-latex-extra psmisc texlive-pstricks libeigen3-dev libxc-dev sudo curl clang-tidy ninja-build libclang-dev llvm-dev \
+       transfig wget libhdf5-dev graphviz pkg-config texlive-latex-extra psmisc texlive-pstricks libeigen3-dev libxc-dev sudo curl pymol clang-tidy ninja-build libclang-dev llvm-dev \
        clang-format software-properties-common zstd libint2-dev libpugixml-dev && \
     apt-get purge --autoremove -y && \
     rm -rf /var/lib/apt/lists/*
@@ -22,7 +22,7 @@ RUN . /etc/os-release && if [ "$VERSION_ID" = "18.04" ]; then \
   rm -rf /var/lib/apt/lists/*; \
 fi
 
-RUN . /etc/os-release && if [ "$VERSION_ID" = "21.10" ]; then \
+RUN . /etc/os-release && if [ "$VERSION_ID" = "21.04" ]; then \
   apt-get install -y libecpint-dev && \
   apt-get purge --autoremove -y && \
   rm -rf /var/lib/apt/lists/*; \

--- a/ubuntu
+++ b/ubuntu
@@ -22,7 +22,7 @@ RUN . /etc/os-release && if [ "$VERSION_ID" = "18.04" ]; then \
   rm -rf /var/lib/apt/lists/*; \
 fi
 
-RUN . /etc/os-release && if [ "$VERSION_ID" = "21.04" ]; then \
+RUN . /etc/os-release && if [ "$VERSION_ID" = "21.10" ]; then \
   apt-get install -y libecpint-dev && \
   apt-get purge --autoremove -y && \
   rm -rf /var/lib/apt/lists/*; \


### PR DESCRIPTION
Reverts votca/buildenv#134

New buildx times out a lot when pushing:
```
Error: buildx call failed with: failed to solve: rpc error: code = Unknown desc = failed commit on ref "layer-sha256:49507e21bb5d0cee4bce2fee3248063d1eff846974de5da2d70f7edc07af9181": no response
```
so reverting to v1 for now.

https://github.com/docker/build-push-action/issues/251