### PR TITLE
ubuntu: rm 18.04 build

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -20,7 +20,6 @@ jobs:
           - {dockerfile: 'ubuntu',   tag: 'latest'}
           - {dockerfile: 'ubuntu',   tag: 'rolling',      build_args: 'TAG=rolling'}
           - {dockerfile: 'ubuntu',   tag: 'devel',        build_args: 'TAG=devel', continue-on-error: 'true'}
-          - {dockerfile: 'ubuntu',   tag: '18.04',        build_args: 'TAG=18.04'}
           - {dockerfile: 'opensuse', tag: 'latest'}
           - {dockerfile: 'fedora',   tag: 'gmx2019_d',    build_args: 'GMX_BRANCH=release-2019,GMX_DOUBLE=ON'}
           - {dockerfile: 'fedora',   tag: 'gmx2019',      build_args: 'GMX_BRANCH=release-2019'}

--- a/ubuntu
+++ b/ubuntu
@@ -14,14 +14,6 @@ RUN apt-get update && \
     apt-get purge --autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
-RUN . /etc/os-release && if [ "$VERSION_ID" = "18.04" ]; then \
-  add-apt-repository -y ppa:git-core/ppa && \
-  apt-get update && \
-  apt-get install -y git && \
-  apt-get purge --autoremove -y && \
-  rm -rf /var/lib/apt/lists/*; \
-fi
-
 RUN . /etc/os-release && if [ "$VERSION_ID" = "21.10" ]; then \
   apt-get install -y libecpint-dev && \
   apt-get purge --autoremove -y && \


### PR DESCRIPTION
Now as stable is update to 2021-dev, we don't need the ubuntu 18.04 container anymore.

Note to self: remove `18.04` tag from https://github.com/orgs/votca/packages/container/package/buildenv%2Fubuntu after this is merged.