### PR TITLE
add blas and lapack

### DIFF
--- a/fedora
+++ b/fedora
@@ -8,7 +8,7 @@ ARG INTEL
 
 RUN ( dnf -y update || dnf -y update ) && \
     dnf -y install \
-      make cmake valgrind git gcc-c++ expat-devel fftw-devel boost-devel txt2tags ccache procps-ng gnuplot-minimal psmisc vim-minimal clang llvm compiler-rt \
+      make cmake valgrind git gcc-c++ expat-devel fftw-devel boost-devel txt2tags ccache procps-ng gnuplot-minimal psmisc vim-minimal clang llvm compiler-rt blas-devel lapack-devel\
       python-pip python3-lxml python3-numpy wget hdf5-devel lammps eigen3-devel libxc-devel python3-espresso-openmpi sudo curl clang-tools-extra python3-cma \
       ninja-build libomp-devel clang-devel llvm-devel python3-sphinx python3-nbsphinx python3-recommonmark python3-sphinx_rtd_theme python3-ipykernel patch \
       python3-seaborn python3-numpydoc zstd  libint2-devel libecpint-devel doxygen python3-rdkit python3-h5py pybind11-devel python3-coverage python3-pytest-cov && \


### PR DESCRIPTION
Adding blas and lapack to fedore with the intention that gromacs picks those up and does not try to compile them itself, so it does crash gcc anymore see
https://github.com/votca/votca/pull/707/checks?check_run_id=2806951119