### PR TITLE
added new packages required for the ase calculator

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -70,4 +70,4 @@ jobs:
           file: ${{ matrix.config.dockerfile }}
           build-args: ${{ steps.build_args.outputs.args }}
           pull: true
-          push: ${{ github.event_name == 'push' ||  github.event_name == 'schedule' }}
+          push: ${{ github.repository_owner == 'votca' && ( github.event_name == 'push' ||  github.event_name == 'schedule' ) }}

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -42,12 +42,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to Gitlab Container Registry
+        if: github.repository_owner == 'votca' && ( github.event_name == 'push' ||  github.event_name == 'schedule' )
         uses: docker/login-action@v2
         with:
           registry: registry.gitlab.com
           username: ${{ secrets.GITLAB_REGISTRY_USERNAME }}
           password: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
       - name: Login to Github Container Registry
+        if: github.repository_owner == 'votca' && ( github.event_name == 'push' ||  github.event_name == 'schedule' )
         uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/fedora
+++ b/fedora
@@ -12,7 +12,7 @@ RUN ( dnf -y update || dnf -y update ) && \
       python-pip python3-lxml python3-numpy wget hdf5-devel lammps eigen3-devel libxc-devel python3-espresso-openmpi sudo curl clang-tools-extra python3-cma \
       ninja-build libomp-devel clang-devel llvm-devel python3-sphinx python3-nbsphinx python3-recommonmark python3-sphinx_rtd_theme python3-ipykernel patch \
       python3-seaborn python3-numpydoc zstd  libint2-devel libecpint-devel doxygen python3-h5py pybind11-devel python3-coverage python3-pytest-cov \
-      openmpi-devel boost-python3-devel python-devel boost-openmpi-devel hdf5-openmpi-devel python3-mpi4py-openmpi python-pip vim && \
+      openmpi-devel boost-python3-devel python-devel boost-openmpi-devel hdf5-openmpi-devel python3-mpi4py-openmpi python-pip vim python-xmltodict python-ase && \
     dnf clean all
 
 RUN source /etc/os-release && if [ "${VERSION_ID}" -le 34 ]; then \

--- a/opensuse
+++ b/opensuse
@@ -9,7 +9,7 @@ RUN zypper dup -y && \
       make cmake valgrind git gcc-c++ libexpat-devel fftw-devel boost-devel txt2tags ccache procps gnuplot psmisc vim clang llvm python3-pip python3-lxml python3-numpy \
       wget hdf5-devel lammps eigen3-devel libxc-devel sudo curl ninja clang-devel llvm-devel libboost_filesystem-devel libboost_program_options-devel libboost_serialization-devel \
       libboost_system-devel libboost_regex-devel libboost_test-devel libboost_timer-devel zlib-devel python3-cma python3-espressomd zstd shadow \
-      libomp-devel libint-devel libecpint-devel doxygen python3-h5py python3-pybind11-devel python3-pytest && \
+      libomp-devel libint-devel libecpint-devel doxygen python3-h5py python3-pybind11-devel python3-pytest python3-xmltodict python-ase && \
     zypper clean
 
 # install opensuse's gromacs

--- a/opensuse
+++ b/opensuse
@@ -9,7 +9,7 @@ RUN zypper dup -y && \
       make cmake valgrind git gcc-c++ libexpat-devel fftw-devel boost-devel txt2tags ccache procps gnuplot psmisc vim clang llvm python3-pip python3-lxml python3-numpy \
       wget hdf5-devel lammps eigen3-devel libxc-devel sudo curl ninja clang-devel llvm-devel libboost_filesystem-devel libboost_program_options-devel libboost_serialization-devel \
       libboost_system-devel libboost_regex-devel libboost_test-devel libboost_timer-devel zlib-devel python3-cma python3-espressomd zstd shadow \
-      libomp-devel libint-devel libecpint-devel doxygen python3-h5py python3-pybind11-devel python3-pytest python3-xmltodict python-ase && \
+      libomp-devel libint-devel libecpint-devel doxygen python3-h5py python3-pybind11-devel python3-pytest python3-xmltodict python3-ase && \
     zypper clean
 
 # install opensuse's gromacs

--- a/ubuntu
+++ b/ubuntu
@@ -10,7 +10,7 @@ RUN apt-get update && \
     apt-get install -y \
        make cmake valgrind git g++ libexpat-dev libfftw3-dev libboost-all-dev txt2tags ccache gnuplot python3-numpy doxygen vim clang llvm python3-pip python3-lxml \
        wget libhdf5-dev graphviz pkg-config psmisc libeigen3-dev libxc-dev sudo curl clang-tidy ninja-build libclang-dev llvm-dev libomp-dev \
-       clang-format software-properties-common zstd libint2-dev libecpint-dev python3-rdkit python3-h5py python3-pytest pybind11-dev && \
+       clang-format software-properties-common zstd libint2-dev libecpint-dev python3-rdkit python3-h5py python3-pytest pybind11-dev python3-xmltodict ase && \
     apt-get purge --autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Hi @junghans , 

Together with @baumeier we are preparing a PR to votca that will add a python interface for xtp based on an ASE calculator. For Votca's CI to pass we need two extra dependencies: xmltodict that is used for the option's handling of the calculator and ASE itself.

This PR adds xmltodict and ase to the different OS. I think the name of the packaged for openSuse and Fedora are correct but I'm not 100% sure.

Best
Nico