### PR TITLE
fedora: drop intel classic compiler

### DIFF
--- a/fedora
+++ b/fedora
@@ -28,7 +28,7 @@ fi
 RUN if [ "${INTEL}" = "yes" ]; then \
   printf "[oneAPI]\nname=Intel oneAPI\nbaseurl=https://yum.repos.intel.com/oneapi\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB" > /etc/yum.repos.d/intel-oneapi.repo && \
   ( dnf -y update || dnf -y update ) && \
-  dnf -y install intel-oneapi-compiler-dpcpp-cpp intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-mkl-devel && \
+  dnf -y install intel-oneapi-compiler-dpcpp-cpp intel-oneapi-mkl-devel && \
   dnf clean all; \
 fi
 


### PR DESCRIPTION
to save space.